### PR TITLE
[VIT-101, VIT-111] Reload and back button

### DIFF
--- a/src/app/home/header/header.component.html
+++ b/src/app/home/header/header.component.html
@@ -1,7 +1,12 @@
 <mat-toolbar color="primary">
+  <span *ngIf="headerService.isBackArrowVisible()"
+    ><button mat-icon-button routerLink="/problem">
+      <mat-icon>arrow_back</mat-icon>
+    </button></span
+  >
   <span><a routerLink="/">vitaL</a></span>
   <span class="spacer"></span>
-  <h1>{{ headerService.getHeaderTitle() | async }}</h1>
+  <h1>{{ headerService.getHeaderTitle() }}</h1>
   <span class="spacer"></span>
   <ngx-auth-firebaseui-avatar></ngx-auth-firebaseui-avatar>
 </mat-toolbar>

--- a/src/app/home/tutorial-page/tutorial-page.component.html
+++ b/src/app/home/tutorial-page/tutorial-page.component.html
@@ -41,9 +41,19 @@
         language
       </mat-icon>
       <mat-card-title>Website</mat-card-title>
+      <span style="flex-grow: 1"></span>
+      <button
+        [disabled]="sandbox.isLoading"
+        [matTooltip]="'Reload Website'"
+        mat-icon-button
+        aria-label="Reload icon"
+        (click)="reloadWebsite()"
+      >
+        <mat-icon>refresh</mat-icon>
+      </button>
     </mat-card-header>
     <mat-card-content>
-      <iframe [src]="sandbox.websiteUrl"></iframe>
+      <iframe #website [src]="sandbox.websiteUrl"></iframe>
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/app/home/tutorial-page/tutorial-page.component.ts
+++ b/src/app/home/tutorial-page/tutorial-page.component.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit, SecurityContext } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  OnInit,
+  SecurityContext,
+  ViewChild
+} from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { SandboxService } from 'src/app/services/http-services/sandbox.service';
@@ -22,6 +28,9 @@ import { HeaderService } from 'src/app/services/utility-services/header.service'
   styleUrls: ['./tutorial-page.component.scss']
 })
 export class TutorialPageComponent implements OnInit {
+  @ViewChild('website')
+  private website: ElementRef<HTMLIFrameElement>;
+
   title = '';
   tutorialContent: IProblemContent = {
     content: { explore: '', exploit: '', mitigate: '' }
@@ -96,6 +105,12 @@ export class TutorialPageComponent implements OnInit {
   tabOrder(a: KeyValue<string, string>, b: KeyValue<string, string>) {
     const possibleKeys = ['explore', 'exploit', 'mitigate'];
     return possibleKeys.indexOf(a.key) - possibleKeys.indexOf(b.key);
+  }
+
+  reloadWebsite() {
+    // https://stackoverflow.com/a/46902311/2950032
+    // Can't use the location.reload because of cross-origin iframe, hence this hack.
+    this.website.nativeElement.src += '';
   }
 
   onValidate() {

--- a/src/app/home/tutorial-page/tutorial-page.component.ts
+++ b/src/app/home/tutorial-page/tutorial-page.component.ts
@@ -22,11 +22,7 @@ import { HeaderService } from 'src/app/services/utility-services/header.service'
   styleUrls: ['./tutorial-page.component.scss']
 })
 export class TutorialPageComponent implements OnInit {
-  // TODO All these are hard-coded. Need to figure out the following
-  // 1. Get them from a service that's triggered as soon as the user selects something in the problems page
-  // 2. Get the types right. Seems hacky right now
-  // 3. Put a loading indicator on all three, till there is content in them
-  title = 'SQL Injection';
+  title = '';
   tutorialContent: IProblemContent = {
     content: { explore: '', exploit: '', mitigate: '' }
   };
@@ -36,9 +32,9 @@ export class TutorialPageComponent implements OnInit {
     websiteUrl: SafeResourceUrl;
     isLoading: boolean;
   } = {
-    terminalUrl: 'http://localhost:3001',
-    websiteUrl: 'http://localhost:5000',
-    isLoading: false
+    terminalUrl: this.getLoadingPageUrl(),
+    websiteUrl: this.getLoadingPageUrl(),
+    isLoading: true
   };
 
   private problem: IProblem;
@@ -69,9 +65,11 @@ export class TutorialPageComponent implements OnInit {
 
     this.setHeaderTitle();
 
-    this.problemListService.getProblemContent(this.problem).subscribe(
-      (contents) => (this.tutorialContent = contents.docs[0].data()) // TODO 0?
-    );
+    this.problemListService
+      .getProblemContent(this.problem)
+      .subscribe(
+        (contents) => (this.tutorialContent = contents.docs[0].data())
+      );
 
     this.sandboxService
       .create(this.problem.serverId)

--- a/src/app/services/utility-services/header.service.ts
+++ b/src/app/services/utility-services/header.service.ts
@@ -1,29 +1,34 @@
 import { Injectable } from '@angular/core';
-import { NavigationEnd, NavigationStart, Router } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
-import { filter, tap } from 'rxjs/operators';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
 })
 export class HeaderService {
-  private title$ = new BehaviorSubject<string>('');
+  private title = '';
+  private backArrowVisible = false;
 
   constructor(private router: Router) {
     // Makes sure the header title is cleared off every time the page changes,
     // so as to not have stale info in the header
     this.router.events
       .pipe(filter((e) => e instanceof NavigationEnd))
-      .subscribe(() => {
+      .subscribe((e: NavigationEnd) => {
         this.setHeaderTitle('');
+        this.backArrowVisible = e.url.includes('tutorial');
       });
   }
 
   setHeaderTitle(title: string) {
-    this.title$.next(title);
+    this.title = title;
   }
 
   getHeaderTitle() {
-    return this.title$;
+    return this.title;
+  }
+
+  isBackArrowVisible() {
+    return this.backArrowVisible;
   }
 }


### PR DESCRIPTION
1. Removed a hard-coded localhost link added as part of #28.
2. Add a reload button for the website.
3. Add a back button in the tutorial page. I tried using iframe's [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) attribute to not add history to the parent window, but since we use form's action attribute to reload the iframe, had to add a `allow-forms` permission, which ended up defeating the purpose. Ideal solution would've been to not use form submit in our sandboxes, and simulate it using JavaScript, but that's also not the best. So, the browser history is basically messed up and we've to use the buttons in the app only to navigate.

Also removed `BehaviourSubject` in a service. Still trying to understand how Angular does re-renders. Will get there eventually.